### PR TITLE
fix: correct mmap file descriptor syntax in hvf_darwin.go

### DIFF
--- a/project/internal/hypervisor/hvf/hvf_darwin.go
+++ b/project/internal/hypervisor/hvf/hvf_darwin.go
@@ -158,7 +158,7 @@ func (v *VM) Start() error {
 		C.size_t(memorySize),
 		C.PROT_READ|C.PROT_WRITE,
 		C.MAP_ANON|C.MAP_PRIVATE,
-		C.-1,
+		-1,
 		0,
 	)
 	if memoryPtr == C.MAP_FAILED {


### PR DESCRIPTION
## Summary
Fixes macOS build failure in hvf_darwin.go by correcting the C.mmap file descriptor syntax.

## Changes
- Changed 'C.-1' to '-1' in mmap call (line 161)

## Build Status
- Linux: ✓ passes
- Darwin: ✓ passes
- All tests pass

## Confidence: 0.95