### PR TITLE
feat: update image pull to accept Docker-style OCI image references

### DIFF
--- a/project/cmd/tent/cli_test.go
+++ b/project/cmd/tent/cli_test.go
@@ -205,7 +205,7 @@ func TestImageCommand(t *testing.T) {
 		subCmdNames[c.Use] = true
 	}
 	
-	requiredSubCmds := []string{"list", "pull <name> [url]"}
+	requiredSubCmds := []string{"list", "pull <image-ref>"}
 	for _, expected := range requiredSubCmds {
 		if !subCmdNames[expected] {
 			t.Errorf("Expected subcommand '%s' not found", expected)
@@ -965,7 +965,8 @@ func TestImagePullCommand_WithUrl(t *testing.T) {
 		t.Fatal("Image pull subcommand not found")
 	}
 	
-	err := pullCmd.ValidateArgs([]string{"ubuntu-22.04", "https://example.com/image.img"})
+	// URL can now be passed directly as the single argument
+	err := pullCmd.ValidateArgs([]string{"https://example.com/image.img"})
 	if err != nil {
 		t.Errorf("Expected no error for image pull with URL, got: %v", err)
 	}

--- a/project/cmd/tent/image.go
+++ b/project/cmd/tent/image.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -66,23 +67,14 @@ func imageListCmd() *cobra.Command {
 
 func imagePullCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "pull <name> [url]",
-		Short: "Download a base rootfs image",
-		Long:  `Download a base rootfs image from a URL.`,
-		Args:  cobra.RangeArgs(1, 2),
+		Use:   "pull <image-ref>",
+		Short: "Download an image from a registry or URL",
+		Long:  `Download an image from a Docker/OCI registry (Docker Hub, GCR, ECR, etc.) or URL.`,
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			name := args[0]
-			url := ""
-			if len(args) > 1 {
-				url = args[1]
-			}
+			imageRef := args[0]
 
-			// Default URLs for common images
-			if url == "" {
-				url = fmt.Sprintf("https://github.com/dalinkstone/tent/releases/download/images/%s.img", name)
-			}
-
-			fmt.Printf("Pulling image '%s' from %s...\n", name, url)
+			fmt.Printf("Pulling image '%s'...\n", imageRef)
 
 			// Create image manager
 			baseDir := os.Getenv("TENT_BASE_DIR")
@@ -96,17 +88,56 @@ func imagePullCmd() *cobra.Command {
 				return fmt.Errorf("failed to create image manager: %w", err)
 			}
 
-			// Pull the image
-			imagePath, err := manager.Pull(name, url)
+			// Determine if this is a Docker-style reference or a URL
+			// Docker references contain '/' (namespace/image), ':' (tag), or both
+			// URLs contain '://' or start with 'http'
+			var imagePath string
+			if isDockerReference(imageRef) {
+				imagePath, err = manager.PullOCI("image", imageRef)
+			} else {
+				// Treat as URL - pull with default name
+				name := "image"
+				if strings.Contains(imageRef, "/") {
+					// Extract name from URL path
+					parts := strings.Split(imageRef, "/")
+					name = strings.TrimSuffix(parts[len(parts)-1], ".img")
+				}
+				imagePath, err = manager.Pull(name, imageRef)
+			}
+
 			if err != nil {
 				return fmt.Errorf("failed to pull image: %w", err)
 			}
 
-			fmt.Printf("Image '%s' pulled successfully to %s\n", name, imagePath)
+			fmt.Printf("Image '%s' pulled successfully to %s\n", imageRef, imagePath)
 			return nil
 		},
 	}
 	return cmd
+}
+
+// isDockerReference checks if the string looks like a Docker/OCI image reference
+// Examples: "ubuntu:22.04", "gcr.io/project/image:tag", "registry.com:5000/repo/image"
+func isDockerReference(ref string) bool {
+	// URLs with http/https protocol
+	if strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://") {
+		return false
+	}
+	// Contains ':' (tag specification) - common in Docker refs
+	if strings.Contains(ref, ":") {
+		return true
+	}
+	// Contains '/' (namespace/repo) - indicates registry or namespace
+	if strings.Contains(ref, "/") {
+		// But check if it's a local file path (contains '..' or starts with './' or '/')
+		if strings.HasPrefix(ref, "./") || strings.HasPrefix(ref, "/") || strings.Contains(ref, "..") {
+			return false
+		}
+		return true
+	}
+	// Simple name without separators - likely just a repo name, treat as Docker ref
+	// Default registry will be used (Docker Hub)
+	return true
 }
 
 func imageExtractCmd() *cobra.Command {


### PR DESCRIPTION
## Summary\nUpdate tent image pull command to accept Docker-style OCI image references (e.g., ubuntu:22.04, gcr.io/project/image:tag) using the existing PullOCI() method.\n\n## Changes\n- cmd/tent/image.go: Changed image pull to accept single <image-ref> argument with Docker-style reference detection\n- cmd/tent/cli_test.go: Updated tests to match new argument signature\n\n## Build Status\n- Compiles clean on Linux: go build ./... ✓\n- Compiles clean on Darwin: GOOS=darwin go build ./... ✓\n- All tests pass: go test ./... -count=1 ✓\n\n## Confidence: 0.85\n---\n*Autonomous PR by stilltent.*