### PR TITLE
feat: implement compose Status query of running VMs when state file is missing

### DIFF
--- a/project/internal/compose/engine.go
+++ b/project/internal/compose/engine.go
@@ -123,7 +123,39 @@ func (m *ComposeManager) Status(name string) (*ComposeStatus, error) {
 			Sandboxes: make(map[string]*SandboxStatus),
 		}
 
-		// TODO: Query running VMs and build status
+		// Query running VMs and build status
+		// Load the compose config to get the list of sandboxes
+		config, err := m.ParseConfig(filepath.Join(m.baseDir, "compose", name, "config.yaml"))
+		if err == nil && config != nil {
+			// Query running VMs
+			allVMs, err := m.vmManager.List()
+			if err == nil {
+				// Build a map of running VM names for quick lookup
+				runningVMs := make(map[string]*models.VMState)
+				for _, vmState := range allVMs {
+					runningVMs[vmState.Name] = vmState
+				}
+
+				// For each sandbox in the compose config, check if it's running
+				for sandboxName := range config.Sandboxes {
+					if vmState, exists := runningVMs[sandboxName]; exists {
+						status.Sandboxes[sandboxName] = &SandboxStatus{
+							Name:   sandboxName,
+							Status: vmState.Status.String(),
+							IP:     vmState.IP,
+							PID:    vmState.PID,
+						}
+					} else {
+						// Sandbox not running
+						status.Sandboxes[sandboxName] = &SandboxStatus{
+							Name:   sandboxName,
+							Status: "stopped",
+						}
+					}
+				}
+			}
+		}
+
 		return status, nil
 	}
 


### PR DESCRIPTION
## Summary

This PR implements the TODO in compose.Status() to query running VMs when the compose state file is missing. When tent compose status name is called but the state file does not exist, the function now loads the compose config to get the list of sandboxes, queries all running VMs using vmManager.List(), and builds status for each sandbox based on whether it is running or not.

## Changes

- internal/compose/engine.go: Updated Status() function to implement running VM query

## Build Status

- Compiles clean on Linux
- Compiles clean on Darwin
- All tests pass

## Confidence: 0.8